### PR TITLE
feat: add search text-sql pair in cached table

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
   'plotly',
   'streamlit',
   'sqlglot',
+  'levenshtein',
 ]
 
 [project.urls]

--- a/src/ibis_birdbrain/bot.py
+++ b/src/ibis_birdbrain/bot.py
@@ -49,6 +49,7 @@ class Bot:
     def __init__(
         self,
         con=ibis.connect("duckdb://"),
+        cached_table=None,
         name="birdbrain",
         user_name="user",
         description=bot_description,
@@ -89,12 +90,20 @@ class Bot:
         body = """TODO"""  # noqa
 
         # system initialization message
+        attachments = [
+                DatabaseAttachment(con, description=self.data_description),
+        ]
+        # need a better way to handle this
+        if str(cached_table) != "None":
+            attachments.append(
+                TableAttachment(cached_table)
+            )    
         system_message = Email(
             body=self.description,
             subject="system initialization",
             to_address=self.name,
             from_address=self.name,
-            attachments=[DatabaseAttachment(con, description=self.data_description)],
+            attachments=attachments,
         )
         self.messages.append(system_message)
         log.info(f"Bot {self.name} initialized...")

--- a/src/ibis_birdbrain/bot.py
+++ b/src/ibis_birdbrain/bot.py
@@ -93,8 +93,8 @@ class Bot:
         attachments = [
                 DatabaseAttachment(con, description=self.data_description),
         ]
-        # need a better way to handle this
-        if str(cached_table) != "None":
+
+        if cached_table is not None:
             attachments.append(
                 TableAttachment(cached_table)
             )    

--- a/src/ibis_birdbrain/flows/data.py
+++ b/src/ibis_birdbrain/flows/data.py
@@ -52,7 +52,7 @@ class DataFlow(Flow):
         table_attachments = messages[-1].attachments.get_attachment_by_type(TableAttachment)  
 
         # check if question is found in cached table
-        search_task_response = self.tasks["search-cahced-question"](messages)
+        search_task_response = self.tasks["search-cached-question"](messages)
         sql_attachment = search_task_response.attachments.get_attachment_by_type(SQLAttachment)
         # initialize response messages
         response_messages = Messages()

--- a/src/ibis_birdbrain/tasks/sql.py
+++ b/src/ibis_birdbrain/tasks/sql.py
@@ -25,7 +25,7 @@ class SearchTextTask(Task):
     """Ibis Birdbrain task to search cached text and SQL pair."""
 
     def __init__(
-        self, name: str = "search-cahced-question", description: str = "Ibis Birdbrain search task"
+        self, name: str = "search-cached-question", description: str = "Ibis Birdbrain search task"
     ) -> None:
         """Initialize the searchtask."""
         super().__init__(name=name, description=description)
@@ -81,19 +81,13 @@ class TextToSQLTask(Task):
         log.info("Text to SQL task")
 
         # get the database attachment and table attachments
-        # TODO: add proper methods for this
-        table_attachments = Attachments()
-        database_attachment = None
-        dialect = "duckdb"
-        for attachment in message.attachments:
-            if isinstance(message.attachments[attachment], DatabaseAttachment):
-                database_attachment = message.attachments[attachment]
-                dialect = database_attachment.open().name
-            elif isinstance(message.attachments[attachment], TableAttachment):
-                table_attachments.append(message.attachments[attachment])
+        table_attachments = message.attachments.get_attachment_by_type(TableAttachment)
+        database_attachment = message.attachments.get_attachment_by_type(DatabaseAttachment)
 
-        assert len(table_attachments) > 0, "No table attachments found"
+        assert table_attachments is not None, "No table attachments found"
         assert database_attachment is not None, "No database attachment found"
+
+        dialect = database_attachment.open().name
 
         # generate the SQL
         sql = self.text_to_sql(


### PR DESCRIPTION
Related issue: #46 

Search question to check if it is in the cached table. 
- pass a cached `Table`
  - schema: question, sql, dialect
- create a search-text-task
  - search the cached table by calculating the [levenshtein normalized edit distance](https://rapidfuzz.github.io/Levenshtein/levenshtein.html#ratio)
- search question before generating sql by LLM


--------------------
**ADDED**

```
from ibis_birdbrain.bot import Bot
import ibis
ibis.options.interactive = True

con = ibis.duckdb.connect()
t = ibis.read_parquet("m.parquet")
con.create_table("mortgage", t.to_pyarrow())


questions = [
    {
        "question": "how many rows in the table",
        "sql": "select count(*) from mortgage",
        "dialect": "duckdb",
    },
    {
        "question": "top 10 rows in the table",
        "sql": "select * from mortgage limit 10",
        "dialect": "duckdb",
    },
]
cached_table = ibis.memtable(questions)
bot = Bot(con=con, cached_table=cached_table)

bot("top 10 rows in the table")
```



